### PR TITLE
Fix update ng-model on change

### DIFF
--- a/dist/ngcalendar.js
+++ b/dist/ngcalendar.js
@@ -27,7 +27,17 @@ if(typeof(window.dhx)=="undefined"){window.dhx=window.dhx4={version:"5.0",skin:n
                     
                     if (attrs.format) {
                         myCalendar.setDateFormat(attrs.format);
-                        myCalendar.attachEvent("onClick", function(){
+			            myCalendar.attachEvent("onChange", function(){
+                            scope.$apply(function () {
+                                scope.ngModel = myCalendar.getFormatedDate(attrs.format);
+                                if(scope.ngTrigger){
+                                    setTimeout(function(){
+                                        scope.ngTrigger(scope.ngModel);
+                                    }, 500);
+                                }
+                            });
+                        });
+			            myCalendar.attachEvent("onClick", function(){
                             scope.$apply(function () {
                                 scope.ngModel = myCalendar.getFormatedDate(attrs.format);
                                 if(scope.ngTrigger){
@@ -39,6 +49,16 @@ if(typeof(window.dhx)=="undefined"){window.dhx=window.dhx4={version:"5.0",skin:n
                         });
                     } else {
                         myCalendar.attachEvent("onClick", function(value){
+                            scope.$apply(function () {
+                                scope.ngModel = value;
+                                if(scope.ngTrigger){
+                                    setTimeout(function(){
+                                        scope.ngTrigger(scope.ngModel);
+                                    }, 500);
+                                }
+                            });
+                        });
+                        myCalendar.attachEvent("onChange", function(value){
                             scope.$apply(function () {
                                 scope.ngModel = value;
                                 if(scope.ngTrigger){


### PR DESCRIPTION
this needed when hours and minutes changed, because some users dont recognize that they should re-select the date after changing the hours/minutes. this fix makes changing the hours/mins in ng-model without selecting the date again.
